### PR TITLE
Redirect to kwontkd.co.uk

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "www.kwontkd.com",
+          },
+        ],
+        destination: "https://www.kwontkd.co.uk/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
We have decided to use kwontkd.co.uk - this PR aims to redirect kwontkd.com to kwontkd.co.uk